### PR TITLE
GCC11 support

### DIFF
--- a/Engine/common_features/crash_handler.cpp
+++ b/Engine/common_features/crash_handler.cpp
@@ -21,6 +21,7 @@
 #include <SDL2/SDL_version.h>
 #include <SDL2/SDL_mixer_ext.h>
 #include <cstdlib>
+#include <exception>
 #include <signal.h>
 #include <common_features/tr.h>
 #include <settings/debugger.h>


### PR DESCRIPTION
Adds support for GCC11. See [https://gcc.gnu.org/gcc-11/porting_to.html#header-dep-changes](https://gcc.gnu.org/gcc-11/porting_to.html#header-dep-changes).