### PR TITLE
Added missing header in image_size.h

### DIFF
--- a/_common/ConfigPackManager/image_size.h
+++ b/_common/ConfigPackManager/image_size.h
@@ -21,6 +21,7 @@
 #define IMAGESIZE_H
 
 #include "PGEString.h"
+#include <cstdint>
 
 struct SDL_RWops;
 


### PR DESCRIPTION
Fixes compilation with recent gcc and clang versions.