### PR TITLE
Read "sendItemPlacing" onto LunaLua

### DIFF
--- a/Editor/testing/ipc/luna_capabilities.cpp
+++ b/Editor/testing/ipc/luna_capabilities.cpp
@@ -54,12 +54,15 @@
 #define DLLCHECK_SMBX2PAL           "LUNALUA 669b266"
 #define DLLCHECK_SMBX2BETA4         "LUNALUA 915bbba"
 #define DLLCHECK_SMBX2BETA4p1       "LUNALUA 82b1b88"
+#define DLLCHECK_SMBX2SEEMod        "LUNALUA SEE MOD"
 
 // Window titles defined in config/game.ini file to heuristically recognize capaitibilites
 #define HEURISTIC_SMBX2BETA3        "Super Mario Bros. X - 2.0.0 (Beta 3)"
 #define HEURISTIC_SMBX2MAGLX3       "Super Mario Bros. X2 - (2.0.0 bMAGLX3)"
 #define HEURISTIC_SMBX2PAL          "Super Mario Bros. X2 - (2.0.0 PAL)"
 #define HEURISTIC_SMBX2b4           "Super Mario Bros. X2 - (2.0.0 b4)"
+
+#define HEURISTIC_SMBX2SEEMod       "Super Mario Bros. X2 (SEE Mod)"
 
 
 /**
@@ -126,6 +129,25 @@ static void fillCapsBeta4(LunaLuaCapabilities &caps)
     caps.ipcCommands << "echo" << "testLevel" <<
                         "getWindowHandle" << "resetCheckPoints" <<
                         "getSupportedFeatures";
+    caps.args << "patch" << "game" << "leveleditor" << "noframeskip" <<
+                 "nosound" << "debugger" << "logger" << "newlauncher" <<
+                 "console" << "nogl" << "testLevel" << "waitForIPC" <<
+                 "hideOnCloseIPC" << "oldLvlLoader" <<
+                 "softGL" << "forceHardGL";
+    caps.isCompatible = true;
+}
+
+/**
+ * @brief Fills capatibilities of SMBX3-Beta4 LunaLua
+ * @param caps Target capatibilities structure
+ */
+static void fillCapsSEEMod(LunaLuaCapabilities &caps)
+{
+    caps.type = "heuristic BETA4";
+    caps.features << "LVLX";
+    caps.ipcCommands << "echo" << "testLevel" <<
+                        "getWindowHandle" << "resetCheckPoints" <<
+                        "getSupportedFeatures" << "sendItemPlacing";
     caps.args << "patch" << "game" << "leveleditor" << "noframeskip" <<
                  "nosound" << "debugger" << "logger" << "newlauncher" <<
                  "console" << "nogl" << "testLevel" << "waitForIPC" <<
@@ -251,6 +273,12 @@ static bool getRawLunaCapabilities(LunaLuaCapabilities &caps, const QString &pat
                 caps.type = "DLL-Check Beta4 Patch 1";
                 return true;
             }
+            else if(a.indexOf(DLLCHECK_SMBX2SEEMod) > 0)
+            {
+                fillCapsSEEMod(caps);
+                caps.type = "DLL-Check SEE Mod";
+                return true;
+            }
             else
             {
                 for(const auto &v : knownButNot)
@@ -327,6 +355,11 @@ static bool getLunaHeuristicCapabilities(LunaLuaCapabilities &caps, const QStrin
         else if(gt.indexOf(HEURISTIC_SMBX2b4) >= 0)
         {
             fillCapsBeta4(caps);
+            return true;
+        }
+        else if(gt.indexOf(HEURISTIC_SMBX2SEEMod) >= 0)
+        {
+            fillCapsSEEMod(caps);
             return true;
         }
 

--- a/Editor/testing/ipc/luna_capabilities.cpp
+++ b/Editor/testing/ipc/luna_capabilities.cpp
@@ -128,7 +128,7 @@ static void fillCapsBeta4(LunaLuaCapabilities &caps)
     caps.features << "LVLX";
     caps.ipcCommands << "echo" << "testLevel" <<
                         "getWindowHandle" << "resetCheckPoints" <<
-                        "getSupportedFeatures";
+                        "getSupportedFeatures" << "sendItemPlacing";
     caps.args << "patch" << "game" << "leveleditor" << "noframeskip" <<
                  "nosound" << "debugger" << "logger" << "newlauncher" <<
                  "console" << "nogl" << "testLevel" << "waitForIPC" <<

--- a/Editor/testing/luna_tester_engine.cpp
+++ b/Editor/testing/luna_tester_engine.cpp
@@ -851,7 +851,7 @@ void LunaTesterEngine::onInputData(const QJsonDocument &input)
 #endif // _WIN32
         }
         break;
-    
+
     case PendC_SendLevel:
         LogDebug("LunaTester: <- Level data has been sent!");
         if(!obj["error"].isNull())

--- a/Editor/testing/luna_tester_engine.cpp
+++ b/Editor/testing/luna_tester_engine.cpp
@@ -64,6 +64,7 @@
 #include <common_features/logger.h>
 #include <dev_console/devconsole.h>
 #include <main_window/global_settings.h>
+#include <networking/engine_intproc.h>
 
 #include "qfile_dialogs_default_options.hpp"
 
@@ -230,6 +231,13 @@ void LunaTesterEngine::init()
                      this, &LunaTesterEngine::gameReadyReadStandardError);
     QObject::connect(&m_lunaGameIPC, &QProcess::readyReadStandardOutput,
                      this, &LunaTesterEngine::gameReadyReadStandardOutput);
+                     
+    QObject::connect(&g_intEngine, &IntEngineSignals::sendPlacingBlock,
+                     this, &LunaTesterEngine::sendPlacingBlock);
+    QObject::connect(&g_intEngine, &IntEngineSignals::sendPlacingNPC,
+                     this, &LunaTesterEngine::sendPlacingNPC);
+    QObject::connect(&g_intEngine, &IntEngineSignals::sendPlacingBGO,
+                     this, &LunaTesterEngine::sendPlacingBGO);
 
     QObject::connect(this, &LunaTesterEngine::testStarted,
                      m_w, &MainWindow::stopMusicForTesting);
@@ -616,6 +624,75 @@ void LunaTesterEngine::gameReadyReadStandardOutput()
     }
 }
 
+void LunaTesterEngine::sendPlacingBlock(const LevelBlock &block)
+{
+    if(!isEngineActive())
+        return;
+    LevelData buffer;
+    FileFormats::CreateLevelData(buffer);
+    buffer.blocks.push_back(block);
+    buffer.layers.clear();
+    buffer.events.clear();
+    QString encoded;
+    if(FileFormats::WriteExtendedLvlFileRaw(buffer, encoded))
+        sendItemPlacing(encoded, PendC_SendPlacingItem);
+}
+
+void LunaTesterEngine::sendPlacingNPC(const LevelNPC &npc)
+{
+    if(!isEngineActive())
+        return;
+    LevelData buffer;
+    FileFormats::CreateLevelData(buffer);
+    buffer.npc.push_back(npc);
+    buffer.layers.clear();
+    buffer.events.clear();
+    QString encoded;
+    if(FileFormats::WriteExtendedLvlFileRaw(buffer, encoded))
+        sendItemPlacing(encoded, PendC_SendPlacingItem);
+}
+
+void LunaTesterEngine::sendPlacingBGO(const LevelBGO &bgo)
+{
+    if(!isEngineActive())
+        return;
+    LevelData buffer;
+    FileFormats::CreateLevelData(buffer);
+    buffer.bgo.push_back(bgo);
+    buffer.layers.clear();
+    buffer.events.clear();
+    QString encoded;
+    if(FileFormats::WriteExtendedLvlFileRaw(buffer, encoded))
+        sendItemPlacing(encoded, PendC_SendPlacingItem);
+}
+
+bool LunaTesterEngine::sendItemPlacing(const QString &rawData, PendingCmd ipcPendCmd)
+{
+    //{"jsonrpc": "2.0", "method": "sendItemPlacing", "params":
+    //   {"sendItemPlacing": <RAW ITEM DATA> }}
+    
+    if(!isEngineActive())
+        return false;
+    QJsonDocument jsonOut;
+    QJsonObject jsonObj;
+    jsonObj["jsonrpc"]  = "2.0";
+    jsonObj["method"]   = "sendItemPlacing";
+    QJsonObject JSONparams;
+    JSONparams["sendItemPlacing"] = rawData;
+    jsonObj["params"] = JSONparams;
+    jsonObj["id"] = static_cast<int>(ipcPendCmd);
+    jsonOut.setObject(jsonObj);
+    
+    LogDebug("ENGINE: Place item command: " + rawData);
+    
+    if (writeToIPC(jsonOut))
+    {
+        m_pendingCommands += ipcPendCmd;
+        return true;
+    }
+    return false;
+}
+
 bool LunaTesterEngine::sendSimpleCommand(const QString &cmd, PendingCmd ipcPendCmd)
 {
     QJsonDocument jsonOut;
@@ -774,7 +851,7 @@ void LunaTesterEngine::onInputData(const QJsonDocument &input)
 #endif // _WIN32
         }
         break;
-
+    
     case PendC_SendLevel:
         LogDebug("LunaTester: <- Level data has been sent!");
         if(!obj["error"].isNull())
@@ -792,6 +869,12 @@ void LunaTesterEngine::onInputData(const QJsonDocument &input)
 
     case PendC_Quit:
         LogDebug("LunaTester: Got a Quit feedback");
+        if(!obj["error"].isNull())
+            lunaErrorMsg(m_w, obj);
+        break;
+    
+    case PendC_SendPlacingItem:
+        LogDebug("LunaTester: Sent editor item to game!");
         if(!obj["error"].isNull())
             lunaErrorMsg(m_w, obj);
         break;

--- a/Editor/testing/luna_tester_engine.cpp
+++ b/Editor/testing/luna_tester_engine.cpp
@@ -872,7 +872,7 @@ void LunaTesterEngine::onInputData(const QJsonDocument &input)
         if(!obj["error"].isNull())
             lunaErrorMsg(m_w, obj);
         break;
-    
+
     case PendC_SendPlacingItem:
         LogDebug("LunaTester: Sent editor item to game!");
         if(!obj["error"].isNull())

--- a/Editor/testing/luna_tester_engine.h
+++ b/Editor/testing/luna_tester_engine.h
@@ -74,7 +74,8 @@ class LunaTesterEngine : public AbstractRuntimeEngine
         PendC_CheckPoint,
         PendC_ShowWindow,
         PendC_Quit,
-        PendC_Kill
+        PendC_Kill,
+        PendC_SendPlacingItem
     };
     QSet<PendingCmd>    m_pendingCommands;
 
@@ -176,6 +177,24 @@ public slots:
      * @brief Change the executable name (apply into config pack specific settings)
      */
     void chooseExeName();
+    
+    /**
+     * @brief Turn on the block placing mode (or change properties)
+     * @param block Block data structure
+     */
+    void sendPlacingBlock(const LevelBlock &block);
+
+    /**
+     * @brief Turn on the BGO placing mode (or change properties)
+     * @param bgo BGO data structure
+     */
+    void sendPlacingBGO(const LevelBGO &bgo);
+
+    /**
+     * @brief Turn on the NPC placing mode (or change properties)
+     * @param npc NPC data structure
+     */
+    void sendPlacingNPC(const LevelNPC &npc);
 
 #ifndef _WIN32
 private:
@@ -209,6 +228,13 @@ private:
 
     void loadSetup();
     void saveSetup();
+    
+    /**
+     * @brief Send a raw data of a placing item
+     * @param raw Encoded setting of an object to place
+     * @return true on a succes sending
+     */
+    bool sendItemPlacing(const QString &rawData, PendingCmd ipcPendCmd);
 
 public:
     explicit LunaTesterEngine(QObject *parent = nullptr);


### PR DESCRIPTION
This is a pull request Part 1 of 2 (Part 2 will be on the LunaLua repo), which relies on sending a entity from Moondust onto X2.

If this pull request is accepted, Part 2's pull request will be possible later on which supports this change.